### PR TITLE
pkg-config in Makefile & gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+ltwheelconf

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
 OBJS=main.o wheelfunctions.o wheels.o
-LIBS=usb-1.0
+CCFLAGS = `pkg-config --cflags libusb-1.0`
+LDFLAGS = `pkg-config --libs libusb-1.0`
 
 all: ltwheelconf
 
 ltwheelconf: $(OBJS)
-	gcc -Wall -l$(LIBS) -g3 -o ltwheelconf $(OBJS)
+	gcc -Wall $(CCFLAGS) -g3 -o ltwheelconf $(OBJS) $(LDFLAGS)
 
 main.o: main.c
-	gcc -Wall -c main.c
+	gcc -Wall $(CCFLAGS) -c main.c
 
 wheels.o: wheels.c wheels.h
-	gcc -Wall -c wheels.c
+	gcc -Wall $(CCFLAGS) -c wheels.c
 
 
 wheelfunctions.o: wheelfunctions.c wheelfunctions.h wheels.h
-	gcc -Wall -c wheelfunctions.c
+	gcc -Wall $(CCFLAGS) -c wheelfunctions.c
 
 clean:
 	rm -rf ltwheelconf $(OBJS)


### PR DESCRIPTION
Hi TripleSpeeder,

I just updated the Makefile to use pkg-config. Due to a libusb-fckup in Ubuntu (11.10, 64-bit), I had to install libusb-1.0 from source but keep the package (dependencies). So using pkg-config was the easiest way to use it and stay as less distribution specific as possible. btw.: Thx for this great tool. Works like a charm (G25 and LFS using wine). :)
